### PR TITLE
Fix select component typing and add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+/dist
+

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -36,8 +36,11 @@ export function Select({ value, onValueChange, children, className = '' }: Selec
     // Support nested SelectContent
     if (child.type && (child.type as any).displayName === 'SelectContent') {
       React.Children.forEach(child.props.children, (sub) => {
-        if (React.isValidElement(sub) && sub.props.value !== undefined) {
-          options.push({ value: sub.props.value, label: sub.props.children });
+        if (React.isValidElement(sub)) {
+          const el = sub as React.ReactElement<{ value?: any; children?: React.ReactNode }>;
+          if (el.props.value !== undefined) {
+            options.push({ value: el.props.value, label: el.props.children });
+          }
         }
       });
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,5 +12,6 @@ export default defineConfig({
   },
   server: {
     port: 5173
-  }
+  },
+  base: './'
 });


### PR DESCRIPTION
## Summary
- fix Select component nested option type handling
- configure Vite base for relative GitHub Pages paths
- add GitHub Pages deployment workflow and .gitignore

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689d7a552d688333a43ed3e497b428c5